### PR TITLE
Fix when passing array types to ContainsOr or ContainsAnd

### DIFF
--- a/Fortis/Search/SearchExtensions.cs
+++ b/Fortis/Search/SearchExtensions.cs
@@ -81,7 +81,9 @@ namespace Fortis.Search
 				 * 								each constant expression against
 				 * 		constant			->	this is the constant expression (value) to be passed to the method
 				 */
-				expressions = constants.Select(constant => Expression.Call(typeof(Enumerable), methodName, typeOfTKey.GenericTypeArguments, keySelector.Body, constant));
+				var typeArgs = typeOfTKey.IsArray ? new[] { typeOfTKey.GetElementType() } : typeOfTKey.GenericTypeArguments;
+
+				expressions = constants.Select(constant => Expression.Call(typeof(Enumerable), methodName, typeArgs, keySelector.Body, constant));
 			}
 
 			/* 


### PR DESCRIPTION
Previously it would try to invoke Enumerable.Contains<T> using only the generic type arguments of the enumerable type passed. Arrays however do not have generic type parameters and instead have element types. This would result in calling Enumerable.Contains() as a non-generic method, which would fail.
