### PR TITLE
Exposed Sitecore LinkField Target property in GeneralLinkFieldWrapper

### DIFF
--- a/Fortis/Model/Fields/GeneralLinkFieldWrapper.cs
+++ b/Fortis/Model/Fields/GeneralLinkFieldWrapper.cs
@@ -36,6 +36,11 @@ namespace Fortis.Model.Fields
 			get { return LinkField.Class; }
 		}
 
+	    public string Target
+	    {
+	        get { return LinkField.Target; }
+	    }
+
 		public override string Url
 		{
 			get
@@ -44,9 +49,10 @@ namespace Fortis.Model.Fields
 				{
 					return Sitecore.Resources.Media.MediaManager.GetMediaUrl(LinkField.TargetItem);
 				}
-				if (IsInternal && Target != null)
+			    var target = GetTarget<IItemWrapper>();
+				if (IsInternal && target != null)
 				{
-					return Target.GenerateUrl();
+					return target.GenerateUrl();
 				}
 
 				return LinkField.Url;

--- a/Fortis/Model/Fields/IGeneralLinkFieldWrapper.cs
+++ b/Fortis/Model/Fields/IGeneralLinkFieldWrapper.cs
@@ -11,5 +11,7 @@
 		bool IsMediaLink { get; }
 
 		string Styles { get; }
+
+        string Target { get; }
 	}
 }

--- a/Fortis/Model/Fields/LinkFieldWrapper.cs
+++ b/Fortis/Model/Fields/LinkFieldWrapper.cs
@@ -9,21 +9,6 @@ namespace Fortis.Model.Fields
 {
 	public class LinkFieldWrapper : FieldWrapper, ILinkFieldWrapper
 	{
-		private IItemWrapper _target;
-
-		protected virtual IItemWrapper Target
-		{
-			get
-			{
-				if (_target == null)
-				{
-					_target = GetTarget<IItemWrapper>();
-				}
-
-				return _target;
-			}
-		}
-
 		public Guid ItemId
 		{
 			get
@@ -48,12 +33,13 @@ namespace Fortis.Model.Fields
 		{
 			get
 			{
-				if (Target == null)
+			    var target = GetTarget<IItemWrapper>();
+				if (target == null)
 				{
 					return string.Empty;
 				}
 
-				return Target.GenerateUrl();
+				return target.GenerateUrl();
 			}
 		}
 


### PR DESCRIPTION
Removed _target memory cache because sitecore will data cache the GetTarget<>() fetch. 
Added Target property to expose the sitecore LinkField.Target property
