### PR TITLE
Datetime values do not come back with Time zone of Sitecore server

### DIFF
--- a/Fortis/Fortis.csproj
+++ b/Fortis/Fortis.csproj
@@ -32,14 +32,13 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Sitecore.ContentSearch">
-      <HintPath>..\_Lib\Sitecore.ContentSearch.dll</HintPath>
+      <HintPath>..\..\..\..\Sidewalk\MyExtraPill\lib\Sitecore.ContentSearch.dll</HintPath>
     </Reference>
-    <Reference Include="Sitecore.ContentSearch.Linq, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\_Lib\Sitecore.ContentSearch.Linq.dll</HintPath>
+    <Reference Include="Sitecore.ContentSearch.Linq">
+      <HintPath>..\..\..\..\Sidewalk\MyExtraPill\lib\Sitecore.ContentSearch.Linq.dll</HintPath>
     </Reference>
     <Reference Include="Sitecore.Kernel">
-      <HintPath>..\_Lib\Sitecore.Kernel.dll</HintPath>
+      <HintPath>..\..\..\..\Sidewalk\MyExtraPill\lib\Sitecore.Kernel.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -74,6 +73,7 @@
     <Compile Include="Model\Fields\NameValueListFieldWrapper.cs" />
     <Compile Include="Model\IRenderingContext.cs" />
     <Compile Include="Model\RenderingContext.cs" />
+    <Compile Include="Model\RenderingParameters\Fields\ImageFieldWrapper.cs" />
     <Compile Include="Model\RenderingParameters\Fields\NumberFieldWrapper.cs" />
     <Compile Include="Model\RenderingParameters\Fields\IntegerFieldWrapper.cs" />
     <Compile Include="Pipelines\RenderField\LinkRenderer.cs" />

--- a/Fortis/Model/ItemFactory.cs
+++ b/Fortis/Model/ItemFactory.cs
@@ -35,7 +35,7 @@ namespace Fortis.Model
 		{
 			if (SpawnProvider.TemplateMapProvider.TemplateMap.ContainsKey(templateId))
 			{
-				return SpawnProvider.TemplateMapProvider.TemplateMap[templateId];
+				return SpawnProvider.TemplateMapProvider.TemplateMap[templateId][0];
 			}
 
 			return typeof(IItemWrapper);

--- a/Fortis/Model/ItemWrapper.cs
+++ b/Fortis/Model/ItemWrapper.cs
@@ -170,7 +170,7 @@ namespace Fortis.Model
 		[TypeConverter(typeof(IndexFieldGuidValueConverter)), IndexField("_template")]
 		public Guid TemplateId
 		{
-			get { return _spawnProvider.TemplateMapProvider.TemplateMap.FirstOrDefault(t => t.Value == this.GetType()).Key; }
+			get { return _spawnProvider.TemplateMapProvider.TemplateMap.FirstOrDefault(t => t.Value.Contains(this.GetType())).Key; }
 		}
 
 		[IndexField("_templates")]

--- a/Fortis/Model/RenderingParameterWrapper.cs
+++ b/Fortis/Model/RenderingParameterWrapper.cs
@@ -61,6 +61,9 @@ namespace Fortis.Model
 						case "integer":
 							_fields[key] = new IntegerFieldWrapper(parameterValue, SpawnProvider);
 							break;
+                        case "image":
+                            _fields[key] = new ImageFieldWrapper(parameterValue, SpawnProvider);
+                            break;
 						default:
 							_fields[key] = new FieldWrapper(parameterValue, SpawnProvider);
 							break;

--- a/Fortis/Model/RenderingParameters/Fields/ImageFieldWrapper.cs
+++ b/Fortis/Model/RenderingParameters/Fields/ImageFieldWrapper.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Web;
+using Fortis.Model.Fields;
+using Fortis.Providers;
+using Sitecore.Data.Fields;
+using Sitecore.Data.Items;
+using Sitecore.Resources.Media;
+using Sitecore.Web.UI.WebControls;
+using Sitecore.Xml;
+
+namespace Fortis.Model.RenderingParameters.Fields
+{
+	public class ImageFieldWrapper : FieldWrapper, IImageFieldWrapper
+	{
+	    private static MediaItem _media;
+	    public MediaItem Media
+	    {
+	        get
+	        {
+	            if (_media != null)
+	                return _media;
+
+	            if (string.IsNullOrWhiteSpace(Value))
+                    return null;
+
+	            var imageId = XmlUtil.GetAttribute("mediaid", XmlUtil.LoadXml(Value));
+	            _media = Sitecore.Context.Database.GetItem(imageId);
+
+                return _media;
+	        }
+	    }
+
+	    public ImageFieldWrapper(string value, ISpawnProvider spawnProvider)
+			: base(value, spawnProvider) { }
+
+		public string AltText => Media?.Alt;
+
+	    public string GetSourceUri()
+	    {
+	        if (Media == null)
+	            return string.Empty;
+
+	        return MediaManager.GetMediaUrl(Media);
+	    }
+
+	    public string GetSourceUri(bool absolute)
+        {
+            if (Media == null)
+            {
+                return string.Empty;
+            }
+
+            return MediaManager.GetMediaUrl(Media, new MediaUrlOptions() { AbsolutePath = absolute });
+        }
+
+	    public IHtmlString Render(ImageFieldWrapperOptions options)
+	    {
+	        throw new NotImplementedException();
+	    }
+
+	    public T GetTarget<T>() where T : IItemWrapper
+	    {
+	        throw new NotImplementedException();
+	    }
+
+	    public string Value { get; set; }
+    }
+}

--- a/Fortis/Providers/ITemplateMapProvider.cs
+++ b/Fortis/Providers/ITemplateMapProvider.cs
@@ -9,9 +9,9 @@ namespace Fortis.Providers
 {
 	public interface ITemplateMapProvider
 	{
-		Dictionary<Guid, Type> TemplateMap { get; }
+        Dictionary<Guid, List<Type>> TemplateMap { get; }
 		Dictionary<Type, Guid> InterfaceTemplateMap { get; }
-		Dictionary<Guid, Type> RenderingParametersTemplateMap { get; }
+        Dictionary<Guid, List<Type>> RenderingParametersTemplateMap { get; }
 		Type GetImplementation<T>() where T : IItemWrapper;
 		bool IsCompatibleTemplate<T>(Guid templateId) where T : IItemWrapper;
 		bool IsCompatibleTemplate(Guid templateId, Type template);

--- a/Fortis/Providers/SpawnProvider.cs
+++ b/Fortis/Providers/SpawnProvider.cs
@@ -128,23 +128,10 @@ namespace Fortis.Providers
 		public IEnumerable<T> FromItems<T>(IEnumerable<Item> items)
 			where T : IItemWrapper
 		{
-			foreach (var item in items)
-			{
-                var wrappedItem = FromItem<IItemWrapper>(item);
-
-			    if (wrappedItem == null)
-			    {
-			        continue;
-			    }
-
-                if (wrappedItem is T)
-			    {
-                    yield return (T)wrappedItem;
-			    }
-			}
+		    return items.Select(FromItem<T>).OfType<T>();
 		}
 
-		public IRenderingParameterWrapper FromRenderingParameters<T>(Item renderingItem, Dictionary<string, string> parameters)
+	    public IRenderingParameterWrapper FromRenderingParameters<T>(Item renderingItem, Dictionary<string, string> parameters)
 			where T : IRenderingParameterWrapper
 		{
 			if (renderingItem != null)

--- a/Fortis/Providers/TemplateMapProvider.cs
+++ b/Fortis/Providers/TemplateMapProvider.cs
@@ -6,199 +6,215 @@ using Fortis.Model;
 
 namespace Fortis.Providers
 {
-	public class TemplateMapProvider : ITemplateMapProvider
-	{
-		private readonly IModelAssemblyProvider _modelAssemblyProvider;
+    public class TemplateMapProvider : ITemplateMapProvider
+    {
+        private readonly IEnumerable<IModelAssemblyProvider> _modelAssemblyProviders;
 
-		public TemplateMapProvider(IModelAssemblyProvider modelAssemblyProvider)
-		{
-			_modelAssemblyProvider = modelAssemblyProvider;
-		}
+        public TemplateMapProvider(IModelAssemblyProvider modelAssemblyProvider)
+        {
+            _modelAssemblyProviders = new List<IModelAssemblyProvider> { modelAssemblyProvider };
+        }
 
-		private object _lock = new object();
-		private Dictionary<Guid, Type> _templateMap = null;
-		public Dictionary<Guid, Type> TemplateMap
-		{
-			get
-			{
-				lock (_lock)
-				{
-					if (_templateMap == null)
-					{
-						_templateMap = new Dictionary<Guid, Type>();
+        public TemplateMapProvider(IEnumerable<IModelAssemblyProvider> modelAssemblyProviders)
+        {
+            _modelAssemblyProviders = modelAssemblyProviders;
+        }
 
-						var types = _modelAssemblyProvider.Assembly.GetTypes();
-						foreach (var t in types)
-						{
-							var customAttributes = t.GetCustomAttributes(typeof (TemplateMappingAttribute), false);
-							foreach (TemplateMappingAttribute templateAttribute in customAttributes)
-							{
-								if (string.IsNullOrEmpty(templateAttribute.Type))
-								{
-									if (!_templateMap.Keys.Contains(templateAttribute.Id))
-									{
-										_templateMap.Add(templateAttribute.Id, t);
-									}
-								}
-							}
-						}
-					}
-					return _templateMap;
-				}
-			}
-		}
+        private object _lock = new object();
+        private Dictionary<Guid, Type> _templateMap = null;
+        public Dictionary<Guid, Type> TemplateMap
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    if (_templateMap == null)
+                    {
+                        _templateMap = new Dictionary<Guid, Type>();
 
-		private Dictionary<Type, Guid> _interfaceTemplateMap;
-		public Dictionary<Type, Guid> InterfaceTemplateMap
-		{
-			get
-			{
-				lock (_lock)
-				{
+                        foreach (var modelAssemblyProvider in _modelAssemblyProviders)
+                        {
+                            var types = modelAssemblyProvider.Assembly.GetTypes();
+                            foreach (var t in types)
+                            {
+                                var customAttributes = t.GetCustomAttributes(typeof(TemplateMappingAttribute), false);
+                                foreach (TemplateMappingAttribute templateAttribute in customAttributes)
+                                {
+                                    if (string.IsNullOrEmpty(templateAttribute.Type))
+                                    {
+                                        if (!_templateMap.Keys.Contains(templateAttribute.Id))
+                                        {
+                                            _templateMap.Add(templateAttribute.Id, t);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    return _templateMap;
+                }
+            }
+        }
 
-					if (_interfaceTemplateMap == null)
-					{
-						_interfaceTemplateMap = new Dictionary<Type, Guid>();
+        private Dictionary<Type, Guid> _interfaceTemplateMap;
+        public Dictionary<Type, Guid> InterfaceTemplateMap
+        {
+            get
+            {
+                lock (_lock)
+                {
 
-						foreach (var t in _modelAssemblyProvider.Assembly.GetTypes())
-						{
-							foreach (
-								TemplateMappingAttribute templateAttribute in t.GetCustomAttributes(typeof (TemplateMappingAttribute), false))
-							{
-								if (string.Equals(templateAttribute.Type, "InterfaceMap"))
-								{
-									if (!_interfaceTemplateMap.Keys.Contains(t))
-									{
-										_interfaceTemplateMap.Add(t, templateAttribute.Id);
-									}
-								}
-							}
-						}
-					}
-					return _interfaceTemplateMap;
-				}
-			}
-		}
+                    if (_interfaceTemplateMap == null)
+                    {
+                        _interfaceTemplateMap = new Dictionary<Type, Guid>();
 
-		private Dictionary<Guid, Type> _renderingParametersTemplateMap = null;
-		public Dictionary<Guid, Type> RenderingParametersTemplateMap
-		{
-			get
-			{
-				lock (_lock)
-				{
+                        foreach (var modelAssemblyProvider in _modelAssemblyProviders)
+                        {
+                            foreach (var t in modelAssemblyProvider.Assembly.GetTypes())
+                            {
+                                foreach (
+                                    TemplateMappingAttribute templateAttribute in
+                                        t.GetCustomAttributes(typeof(TemplateMappingAttribute), false))
+                                {
+                                    if (string.Equals(templateAttribute.Type, "InterfaceMap"))
+                                    {
+                                        if (!_interfaceTemplateMap.Keys.Contains(t))
+                                        {
+                                            _interfaceTemplateMap.Add(t, templateAttribute.Id);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    return _interfaceTemplateMap;
+                }
+            }
+        }
 
-					if (_renderingParametersTemplateMap == null)
-					{
-						_renderingParametersTemplateMap = new Dictionary<Guid, Type>();
-						foreach (var t in _modelAssemblyProvider.Assembly.GetTypes())
-						{
-							foreach (
-								TemplateMappingAttribute templateAttribute in t.GetCustomAttributes(typeof (TemplateMappingAttribute), false))
-							{
-								if (templateAttribute.Type == "RenderingParameter")
-								{
-									if (!_renderingParametersTemplateMap.Keys.Contains(templateAttribute.Id))
-									{
-										_renderingParametersTemplateMap.Add(templateAttribute.Id, t);
-									}
-								}
-							}
-						}
-					}
+        private Dictionary<Guid, Type> _renderingParametersTemplateMap = null;
+        public Dictionary<Guid, Type> RenderingParametersTemplateMap
+        {
+            get
+            {
+                lock (_lock)
+                {
 
-					return _renderingParametersTemplateMap;
-				}
-			}
-		}
+                    if (_renderingParametersTemplateMap == null)
+                    {
+                        _renderingParametersTemplateMap = new Dictionary<Guid, Type>();
 
-		public Type GetImplementation<T>() where T : IItemWrapper
-		{
-			var typeOfT = typeof(T);
+                        foreach (var modelAssemblyProvider in _modelAssemblyProviders)
+                        {
+                            foreach (var t in modelAssemblyProvider.Assembly.GetTypes())
+                            {
+                                foreach (
+                                    TemplateMappingAttribute templateAttribute in t.GetCustomAttributes(typeof(TemplateMappingAttribute), false))
+                                {
+                                    if (templateAttribute.Type == "RenderingParameter")
+                                    {
+                                        if (!_renderingParametersTemplateMap.Keys.Contains(templateAttribute.Id))
+                                        {
+                                            _renderingParametersTemplateMap.Add(templateAttribute.Id, t);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
 
-			if (!typeOfT.IsInterface)
-			{
-				throw new Exception("Fortis: An interface implementing IITemWrapper must be passed as the generic argument to get the corresponding implementation. " + typeOfT.Name + " is not an interface.");
-			}
+                    return _renderingParametersTemplateMap;
+                }
+            }
+        }
 
-			if (!InterfaceTemplateMap.ContainsKey(typeOfT))
-			{
-				throw new Exception("Fortis: Type " + typeOfT.Name + " does not exist in interface template map");
-			}
+        public Type GetImplementation<T>() where T : IItemWrapper
+        {
+            var typeOfT = typeof(T);
 
-			var templateId = InterfaceTemplateMap[typeOfT];
+            if (!typeOfT.IsInterface)
+            {
+                throw new Exception("Fortis: An interface implementing IITemWrapper must be passed as the generic argument to get the corresponding implementation. " + typeOfT.Name + " is not an interface.");
+            }
 
-			if (!TemplateMap.ContainsKey(templateId))
-			{
-				throw new Exception("Fortis: Template ID " + templateId + " does not exist in template map");
-			}
+            if (!InterfaceTemplateMap.ContainsKey(typeOfT))
+            {
+                throw new Exception("Fortis: Type " + typeOfT.Name + " does not exist in interface template map");
+            }
 
-			return TemplateMap[templateId];
-		}
+            var templateId = InterfaceTemplateMap[typeOfT];
 
-		public bool IsCompatibleTemplate<T>(Guid templateId) where T : IItemWrapper
-		{
-			return IsCompatibleTemplate(templateId, typeof(T));
-		}
+            if (!TemplateMap.ContainsKey(templateId))
+            {
+                throw new Exception("Fortis: Template ID " + templateId + " does not exist in template map");
+            }
 
-		public bool IsCompatibleTemplate(Guid templateId, Type template)
-		{
-			// template Type must at least implement IItemWrapper
-			if (template != typeof(IItemWrapper))
-			{
-				// TODO: Implement
-			}
+            return TemplateMap[templateId];
+        }
 
-			return true;
-		}
+        public bool IsCompatibleTemplate<T>(Guid templateId) where T : IItemWrapper
+        {
+            return IsCompatibleTemplate(templateId, typeof(T));
+        }
 
-		public bool IsCompatibleFieldType<T>(string fieldType) where T : IFieldWrapper
-		{
-			return IsCompatibleFieldType(fieldType, typeof(T));
-		}
+        public bool IsCompatibleTemplate(Guid templateId, Type template)
+        {
+            // template Type must at least implement IItemWrapper
+            if (template != typeof(IItemWrapper))
+            {
+                // TODO: Implement
+            }
 
-		public bool IsCompatibleFieldType(string scFieldType, Type fieldType)
-		{
-			switch (scFieldType.ToLower())
-			{
-				case "checkbox":
-					return fieldType == typeof(BooleanFieldWrapper);
-				case "image":
-					return fieldType == typeof(ImageFieldWrapper);
-				case "date":
-				case "datetime":
-					return fieldType == typeof(DateTimeFieldWrapper);
-				case "checklist":
-				case "treelist":
-				case "treelistex":
-				case "multilist":
-				case "multilist with search":
-				case "treelist with search":
-					return fieldType == typeof(ListFieldWrapper);
-				case "file":
-					return fieldType == typeof(FileFieldWrapper);
-				case "droplink":
-				case "droptree":
-					return fieldType == typeof(LinkFieldWrapper);
-				case "general link":
-				case "general link with search":
-					return fieldType == typeof(GeneralLinkFieldWrapper);
-				case "text":
-				case "single-line text":
-				case "multi-line text":
-				case "droplist":
-					return fieldType == typeof(TextFieldWrapper);
-				case "rich text":
-					return fieldType == typeof(RichTextFieldWrapper);
-				case "number":
-					return fieldType == typeof(NumberFieldWrapper);
-				case "integer":
-					return fieldType == typeof(IntegerFieldWrapper);
-				case "name value list":
-					return fieldType == typeof(NameValueListFieldWrapper);
-				default:
-					return false;
-			}
-		}
-	}
+            return true;
+        }
+
+        public bool IsCompatibleFieldType<T>(string fieldType) where T : IFieldWrapper
+        {
+            return IsCompatibleFieldType(fieldType, typeof(T));
+        }
+
+        public bool IsCompatibleFieldType(string scFieldType, Type fieldType)
+        {
+            switch (scFieldType.ToLower())
+            {
+                case "checkbox":
+                    return fieldType == typeof(BooleanFieldWrapper);
+                case "image":
+                    return fieldType == typeof(ImageFieldWrapper);
+                case "date":
+                case "datetime":
+                    return fieldType == typeof(DateTimeFieldWrapper);
+                case "checklist":
+                case "treelist":
+                case "treelistex":
+                case "multilist":
+                case "multilist with search":
+                case "treelist with search":
+                    return fieldType == typeof(ListFieldWrapper);
+                case "file":
+                    return fieldType == typeof(FileFieldWrapper);
+                case "droplink":
+                case "droptree":
+                    return fieldType == typeof(LinkFieldWrapper);
+                case "general link":
+                case "general link with search":
+                    return fieldType == typeof(GeneralLinkFieldWrapper);
+                case "text":
+                case "single-line text":
+                case "multi-line text":
+                case "droplist":
+                    return fieldType == typeof(TextFieldWrapper);
+                case "rich text":
+                    return fieldType == typeof(RichTextFieldWrapper);
+                case "number":
+                    return fieldType == typeof(NumberFieldWrapper);
+                case "integer":
+                    return fieldType == typeof(IntegerFieldWrapper);
+                case "name value list":
+                    return fieldType == typeof(NameValueListFieldWrapper);
+                default:
+                    return false;
+            }
+        }
+    }
 }

--- a/Fortis/Providers/TemplateMapProvider.cs
+++ b/Fortis/Providers/TemplateMapProvider.cs
@@ -21,8 +21,9 @@ namespace Fortis.Providers
         }
 
         private object _lock = new object();
-        private Dictionary<Guid, Type> _templateMap = null;
-        public Dictionary<Guid, Type> TemplateMap
+        private Dictionary<Guid, List<Type>> _templateMap = null;
+
+        public Dictionary<Guid, List<Type>> TemplateMap
         {
             get
             {
@@ -30,7 +31,7 @@ namespace Fortis.Providers
                 {
                     if (_templateMap == null)
                     {
-                        _templateMap = new Dictionary<Guid, Type>();
+                        _templateMap = new Dictionary<Guid, List<Type>>();
 
                         foreach (var modelAssemblyProvider in _modelAssemblyProviders)
                         {
@@ -44,7 +45,11 @@ namespace Fortis.Providers
                                     {
                                         if (!_templateMap.Keys.Contains(templateAttribute.Id))
                                         {
-                                            _templateMap.Add(templateAttribute.Id, t);
+                                            _templateMap.Add(templateAttribute.Id, new List<Type> {t});
+                                        }
+                                        else
+                                        {
+                                            _templateMap[templateAttribute.Id].Add(t);
                                         }
                                     }
                                 }
@@ -92,8 +97,8 @@ namespace Fortis.Providers
             }
         }
 
-        private Dictionary<Guid, Type> _renderingParametersTemplateMap = null;
-        public Dictionary<Guid, Type> RenderingParametersTemplateMap
+        private Dictionary<Guid, List<Type>> _renderingParametersTemplateMap = null;
+        public Dictionary<Guid, List<Type>> RenderingParametersTemplateMap
         {
             get
             {
@@ -102,7 +107,7 @@ namespace Fortis.Providers
 
                     if (_renderingParametersTemplateMap == null)
                     {
-                        _renderingParametersTemplateMap = new Dictionary<Guid, Type>();
+                        _renderingParametersTemplateMap = new Dictionary<Guid, List<Type>>();
 
                         foreach (var modelAssemblyProvider in _modelAssemblyProviders)
                         {
@@ -115,7 +120,11 @@ namespace Fortis.Providers
                                     {
                                         if (!_renderingParametersTemplateMap.Keys.Contains(templateAttribute.Id))
                                         {
-                                            _renderingParametersTemplateMap.Add(templateAttribute.Id, t);
+                                            _renderingParametersTemplateMap.Add(templateAttribute.Id, new List<Type> {t});
+                                        }
+                                        else
+                                        {
+                                            _renderingParametersTemplateMap[templateAttribute.Id].Add(t);
                                         }
                                     }
                                 }
@@ -149,7 +158,13 @@ namespace Fortis.Providers
                 throw new Exception("Fortis: Template ID " + templateId + " does not exist in template map");
             }
 
-            return TemplateMap[templateId];
+            foreach (var type in TemplateMap[templateId])
+            {
+                if (typeOfT.IsAssignableFrom(type))
+                    return type;
+            }
+
+            return null;
         }
 
         public bool IsCompatibleTemplate<T>(Guid templateId) where T : IItemWrapper


### PR DESCRIPTION
When you save a datetime in Sitecore, the raw value is stored in UTC format.
But when you retrieve this value after the mapping of Fortis, the time is still in UTC format.
The extpected value is the time as entered in Sitecore (with the correct time zone).

Example:
- Time encoded in Sitecore : 11h00
- Time saved in Sitecore: 09h00
- Time retrieved by Fortis: 09h00
- Expected: 11h00