### PR TITLE
fix for HasValue property

### DIFF
--- a/src/Fortis/Model/Fields/IntegerFieldWrapper.cs
+++ b/src/Fortis/Model/Fields/IntegerFieldWrapper.cs
@@ -28,23 +28,31 @@ namespace Fortis.Model.Fields
 		{
 			get
 			{
-				if (!IsLazy && !_value.HasValue)
-				{
-					long parsedValue;
-
-					if (long.TryParse(RawValue, out parsedValue))
-					{
-						_value = parsedValue;
-					}
-				}
-
-				return _value.Value;
+			    InitializeValue();
+                return _value.Value;
 			}
 		}
 
 		public override bool HasValue
 		{
-			get { return _value.HasValue; }
+		    get
+		    {
+                InitializeValue();
+                return _value.HasValue;
+		    }
 		}
+
+	    protected void InitializeValue()
+	    {
+            if (!IsLazy && !_value.HasValue)
+            {
+                long parsedValue;
+
+                if (long.TryParse(RawValue, out parsedValue))
+                {
+                    _value = parsedValue;
+                }
+            }
+        }
 	}
 }

--- a/src/Fortis/Model/Fields/NameValueListFieldWrapper.cs
+++ b/src/Fortis/Model/Fields/NameValueListFieldWrapper.cs
@@ -49,23 +49,35 @@ namespace Fortis.Model.Fields
 		{
 			get
 			{
-				if (_value == null)
-				{
-					if (string.IsNullOrWhiteSpace(this.RawValue))
-					{
-						return new NameValueCollection(0);
-					}
+			    InitializeValue();
 
-					this._value = HttpUtility.ParseQueryString(this.RawValue);
-				}
+                if (_value == null)
+			    {
+                    return new NameValueCollection();
+			    }
 
-				return _value;
+			    return _value;
 			}
 		}
 
-		public override bool HasValue
+        public override bool HasValue
 		{
-			get { return _value != null && _value.Count > 0;  }
+            get
+            {
+                InitializeValue();
+                return _value != null && _value.Count > 0;
+            }
 		}
+
+	    protected void InitializeValue()
+	    {
+            if (_value == null)
+            {
+                if (!string.IsNullOrWhiteSpace(this.RawValue))
+                {
+                    this._value = HttpUtility.ParseQueryString(this.RawValue);
+                }
+            }
+        }
 	}
 }

--- a/src/Fortis/Model/Fields/NumberFieldWrapper.cs
+++ b/src/Fortis/Model/Fields/NumberFieldWrapper.cs
@@ -21,25 +21,34 @@ namespace Fortis.Model.Fields
 
 		public override bool HasValue
 		{
-			get { return _value.HasValue; }
+		    get
+		    {
+		        InitializeValue();
+                return _value.HasValue;
+		    }
 		}
 
 		public float Value
 		{
 			get
 			{
-				if (!IsLazy && !_value.HasValue)
-				{
-					float parsedValue;
+			    this.InitializeValue();
 
-					if (float.TryParse(RawValue, out parsedValue))
-					{
-						_value = parsedValue;
-					}
-				}
-
-				return _value.Value;
+                return _value.Value;
 			}
 		}
+
+	    protected void InitializeValue()
+	    {
+            if (!IsLazy && !_value.HasValue)
+            {
+                float parsedValue;
+
+                if (float.TryParse(RawValue, out parsedValue))
+                {
+                    _value = parsedValue;
+                }
+            }
+        }
 	}
 }


### PR DESCRIPTION
HasValue property did not work for IntegerFieldWrapper, NumberFieldWrapper and NameValueListFieldWrapper.

The _value field was not set when calling HasValue and it returned false.
Fixed this so HasValue tries to initialize _value field if its was not initialized.