### PR TITLE
Ensure indexableItem isn't null

### DIFF
--- a/Fortis/Search/ComputedFields/InheritedTemplates.cs
+++ b/Fortis/Search/ComputedFields/InheritedTemplates.cs
@@ -25,7 +25,14 @@ namespace Fortis.Search.ComputedFields
 
 		public object ComputeFieldValue(IIndexable indexable)
 		{
-			return GetAllTemplates(indexable as SitecoreIndexableItem);
+			var indexableItem = indexable as SitecoreIndexableItem;
+
+			if (indexableItem == null)
+			{
+				return null;
+			}
+
+			return GetAllTemplates(indexableItem);
 		}
 
 		private static List<string> GetAllTemplates(Item item)

--- a/Fortis/Search/ComputedFields/IsStandardValues.cs
+++ b/Fortis/Search/ComputedFields/IsStandardValues.cs
@@ -19,6 +19,12 @@ namespace Fortis.Search.ComputedFields
 		public object ComputeFieldValue(IIndexable indexable)
 		{
 			var item = (Item)(indexable as SitecoreIndexableItem);
+
+			if (item == null)
+			{
+				return null;
+			}
+
 			var isStandardValues = StandardValuesManager.IsStandardValuesHolder(item);
 
 			return isStandardValues;


### PR DESCRIPTION
On Sitecore 8.0, computed fields will throw an exception when passed an analytics indexable.

```
ManagedPoolThread #2 21:06:52 INFO  Crawler [sitecore_analytics_index]: 1 items to index
ManagedPoolThread #2 21:06:52 ERROR Could not compute value for ComputedIndexField: _isstandardvalues for indexable: visit|57bb2300-7ffc-4c51-8b6b-aa678e535c0b
Exception: System.ArgumentNullException
Message: Value cannot be null.
Parameter name: item
Source: Sitecore.Kernel
   at Sitecore.Diagnostics.Assert.ArgumentNotNull(Object argument, String argumentName)
   at Sitecore.Data.StandardValuesProvider.IsStandardValuesHolder(Item item)
   at Fortis.Search.ComputedFields.IsStandardValues.ComputeFieldValue(IIndexable indexable)
   at Sitecore.ContentSearch.LuceneProvider.LuceneDocumentBuilder.AddComputedIndexFields()

ManagedPoolThread #2 21:06:52 ERROR Could not compute value for ComputedIndexField: _templates for indexable: visit|57bb2300-7ffc-4c51-8b6b-aa678e535c0b
Exception: System.ArgumentNullException
Message: Value cannot be null.
Parameter name: item
Source: Sitecore.Kernel
   at Sitecore.Diagnostics.Assert.ArgumentNotNull(Object argument, String argumentName)
   at Fortis.Search.ComputedFields.InheritedTemplates.GetAllTemplates(Item item)
   at Sitecore.ContentSearch.LuceneProvider.LuceneDocumentBuilder.AddComputedIndexFields()
```

This fix resolves that.